### PR TITLE
Fix #82: machines don't return to initial position on reset

### DIFF
--- a/Assets/Scripts/StageReset.cs
+++ b/Assets/Scripts/StageReset.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using AGXUnity;
 using AGXUnity.Collide;
 using AGXUnity.Model;
+using PWRISimulator.ROS;
 
 namespace PWRISimulator
 {
@@ -26,6 +27,15 @@ namespace PWRISimulator
         private Vector3 shovelPos;
         private Quaternion shovelQut;
 
+        // リセット時にダンプトラックを初期位置に復元するための保存データ
+        private struct DumpTruckSaveData
+        {
+            public string name;
+            public Vector3 position;
+            public Quaternion rotation;
+        }
+        private List<DumpTruckSaveData> savedDumpTrucks = new List<DumpTruckSaveData>();
+
         // Start is called before the first frame update
         void Start()
         {
@@ -40,6 +50,71 @@ namespace PWRISimulator
                 shovelName = shovelObj.name;
                 shovelPos = shovelObj.transform.position;
                 shovelQut = shovelObj.transform.rotation;
+            }
+
+            // ダンプトラックの初期位置を保存
+            SaveDumpTruckPositions();
+        }
+
+        /// <summary>
+        /// 現在配置されているダンプトラックの位置・姿勢を保存する。
+        /// Dump_ObjListに加えて、FindObjectsOfTypeでリスト外のトラックも検索する。
+        /// </summary>
+        void SaveDumpTruckPositions()
+        {
+            savedDumpTrucks.Clear();
+
+            // Dump_ObjListから保存
+            var seen = new HashSet<GameObject>();
+            for (int i = 0; i < GlobalVariables.Dump_ObjList.Count; i++)
+            {
+                GameObject dumpObj = GlobalVariables.Dump_ObjList[i];
+                if (dumpObj == null || seen.Contains(dumpObj))
+                    continue;
+                seen.Add(dumpObj);
+                savedDumpTrucks.Add(new DumpTruckSaveData
+                {
+                    name = dumpObj.name,
+                    position = dumpObj.transform.position,
+                    rotation = dumpObj.transform.rotation
+                });
+            }
+
+            // FindObjectsOfTypeでリスト外のトラックも検索して保存
+            foreach (var dumpInput in FindObjectsOfType<DumpTruckInput>(true))
+            {
+                var dumpRoot = dumpInput.transform.root.gameObject;
+                if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name) && !seen.Contains(dumpRoot))
+                {
+                    seen.Add(dumpRoot);
+                    savedDumpTrucks.Add(new DumpTruckSaveData
+                    {
+                        name = dumpRoot.name,
+                        position = dumpRoot.transform.position,
+                        rotation = dumpRoot.transform.rotation
+                    });
+                }
+            }
+
+            UnityEngine.Debug.Log("StageReset: Saved " + savedDumpTrucks.Count + " dump truck(s) for reset.");
+        }
+
+        /// <summary>
+        /// 保存した位置・姿勢でダンプトラックを再配置する。
+        /// </summary>
+        void RespawnDumpTrucks()
+        {
+            var ic120obj = new ic120obj();
+            foreach (var saved in savedDumpTrucks)
+            {
+                // IDを名前から抽出
+                int lastUnderscore = saved.name.LastIndexOf("_");
+                int spawnID = 0;
+                if (lastUnderscore >= 0 && int.TryParse(saved.name.Substring(lastUnderscore + 1), out int parsed))
+                    spawnID = parsed;
+
+                ic120obj.Spawn_ic120(saved.position, saved.rotation, spawnID, SpawnObject.ic120_path);
+                GlobalVariables.ic120Counter++;
             }
         }
 
@@ -58,13 +133,17 @@ namespace PWRISimulator
                     terrain = FindObjectOfType<DeformableTerrain>();
                 }
 
-                // 土壌粒子モデルを削除
+                // 土壌粒子モデルを削除（降順で削除してインデックスを安定させる）
                 var soilSim = terrain.Native?.getSoilSimulationInterface();
-                var soilParticles = soilSim.getSoilParticles();
-
-                for (uint i = 0; i < soilParticles.size(); i++)
+                if (soilSim != null)
                 {
-                    soilSim.removeSoilParticle(soilParticles.at(i));
+                    var soilParticles = soilSim.getSoilParticles();
+                    for (int i = (int)soilParticles.size() - 1; i >= 0; i--)
+                    {
+                        var particle = soilParticles.at((uint)i);
+                        soilSim.removeSoilParticle(particle);
+                        particle.ReturnToPool();
+                    }
                 }
 
 
@@ -79,11 +158,12 @@ namespace PWRISimulator
                 TerrainScore.Reset();
 
 
-                // ショベルカーを削除
+                // ショベルカーを削除（SetActive(false)でAGXコールバックを解除してからDestroy）
                 shovelObj = Zx200ObjectUtility.FindZx200Object();
                 if (shovelObj != null)
                 {
                     shovelName = shovelObj.name;
+                    shovelObj.SetActive(false);
                     UnityEngine.Object.Destroy(shovelObj);
                 }
 
@@ -91,21 +171,39 @@ namespace PWRISimulator
                 UnityEngine.Debug.Log("Dump_IDList.Count: " + GlobalVariables.Dump_IDList.Count);
                 UnityEngine.Debug.Log("Dump_ObjList.Count: " + GlobalVariables.Dump_ObjList.Count);
 
-                // ダンプトラック削除
+                // 削除対象のダンプトラックを収集（Dump_ObjList + FindObjectsOfType）
+                var dumpObjectsToDestroy = new HashSet<GameObject>();
                 for (int i = 0; i < GlobalVariables.Dump_ObjList.Count; i++)
                 {
-                    UnityEngine.Debug.Log("ID: " + GlobalVariables.Dump_IDList[i]);
+                    if (GlobalVariables.Dump_ObjList[i] != null)
+                        dumpObjectsToDestroy.Add(GlobalVariables.Dump_ObjList[i]);
+                }
+                foreach (var dumpInput in FindObjectsOfType<DumpTruckInput>(true))
+                {
+                    var dumpRoot = dumpInput.transform.root.gameObject;
+                    if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name))
+                        dumpObjectsToDestroy.Add(dumpRoot);
+                }
 
-                    GameObject dumpObj = GlobalVariables.Dump_ObjList[i];
-
+                // ダンプトラック削除（SetActive(false)でAGXコールバックを解除してからDestroy）
+                foreach (GameObject dumpObj in dumpObjectsToDestroy)
+                {
                     if (dumpObj != null)
                     {
-                        // 削除
-                        Destroy(dumpObj);
+                        dumpObj.SetActive(false);
+                        UnityEngine.Object.Destroy(dumpObj);
                         GameObject objMassBody = GameObject.Find(dumpObj.name + "_SoilMassBody");
-                        if (objMassBody != null) Destroy(objMassBody);
+                        if (objMassBody != null)
+                        {
+                            objMassBody.SetActive(false);
+                            UnityEngine.Object.Destroy(objMassBody);
+                        }
                         GameObject objMassJoint = GameObject.Find(dumpObj.name + "_SoilMassJoint");
-                        if (objMassJoint != null) Destroy(objMassJoint);
+                        if (objMassJoint != null)
+                        {
+                            objMassJoint.SetActive(false);
+                            UnityEngine.Object.Destroy(objMassJoint);
+                        }
                     }
                 }
 
@@ -131,6 +229,10 @@ namespace PWRISimulator
                 // ショベルカー
                 var cameraObj = shovelObj.transform.Find("base_link/track_link/CameraStr").gameObject;
                 cameraObj.SetActive(false);
+
+
+                // ダンプトラック再配置
+                RespawnDumpTrucks();
 
 
                 //GlobalVariables.ForceCameraChange = true;

--- a/Assets/Scripts/StageReset.cs
+++ b/Assets/Scripts/StageReset.cs
@@ -84,7 +84,7 @@ namespace PWRISimulator
             foreach (var dumpInput in FindObjectsOfType<DumpTruckInput>(true))
             {
                 var dumpRoot = dumpInput.transform.root.gameObject;
-                if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name) && !seen.Contains(dumpRoot))
+                if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name) && !seen.Contains(dumpRoot) && dumpRoot.activeSelf)
                 {
                     seen.Add(dumpRoot);
                     savedDumpTrucks.Add(new DumpTruckSaveData


### PR DESCRIPTION
## Summary

Fixes #82 — when Reset is pressed, the dump truck (ic120) and sometimes the excavator (zx200) don't return to their initial positions. This happens frequently when the simulation is interrupted mid-run.

### Root Cause

Three bugs in `StageReset.cs`, identified by comparison with `btn_loadScript.cs` (Load):

1. **Dump trucks not saved/respawned (primary):** `Start()` only saved the shovel's position. Reset destroyed dump trucks but never respawned them — so ic120 simply disappeared instead of returning to its initial position.

2. **Missing `SetActive(false)` before `Destroy()`:** `Destroy()` is deferred to end-of-frame. Without deactivating first, old AGXUnity components (RigidBody, Track) remain registered in step callbacks and conflict with newly instantiated objects in the same frame. This was already fixed in `btn_loadScript.cs` and commit `d8f6a8a0`, but not merged to hackathon. This explains the "時々" (sometimes) frequency — the conflict depends on simulation state.

3. **Soil particle removal loop bug:** `for (i = 0; i < size(); i++)` with `removeSoilParticle()` inside shrinks the collection during iteration, causing every other particle to be skipped. Fixed by iterating in descending order.

### Changes (`Assets/Scripts/StageReset.cs`)

- **`Start()`**: Added `SaveDumpTruckPositions()` — saves name/position/rotation of all dump trucks from `Dump_ObjList` + `FindObjectsOfType<DumpTruckInput>(true)` fallback
- **`Update()` (reset path)**:
  - Added `SetActive(false)` before `Destroy()` for shovel, dump trucks, and SoilMassBody/SoilMassJoint
  - Added `FindObjectsOfType<DumpTruckInput>(true)` to collect unlisted dump trucks for destruction
  - Fixed soil particle loop to iterate descending with `ReturnToPool()`
  - Added `RespawnDumpTrucks()` call after shovel respawn
- **New methods**: `SaveDumpTruckPositions()`, `RespawnDumpTrucks()`

### Test plan
- [x] No compilation errors
- [x] Existing EditMode tests pass (17/17: DumpVesselStateController + DumpSoilCapture)
- [ ] Manual test: place dump truck, drive it, press Reset, verify it returns to initial position
- [ ] Manual test: interrupt simulation mid-run, press Reset, verify both ic120 and zx200 return to initial positions

Generated with [Devin](https://devin.ai)