### PR TITLE
PR #94 レビュー対応と Save/Load・ROS 配信まわりの修正一式

### DIFF
--- a/Assets/Other3rdParty/RuntimeGizmo/TransformGizmo.cs
+++ b/Assets/Other3rdParty/RuntimeGizmo/TransformGizmo.cs
@@ -875,6 +875,10 @@ namespace RuntimeGizmos
 						{
 							//Debug.Log("test");
 							//20250829 subdisp.GetComponent<Subdisplay>().SetDisplay(target.Find("Camera").gameObject.GetComponent<Camera>());
+							// カメラ切替で非アクティブになっていると描画されずプレビューが真っ黒のままになるため、
+							// 機体の分岐と同様に点灯してから表示する (#150)
+							target.Find("CameraStr").gameObject.SetActive(true);
+							target.Find("CameraStr/Camera").gameObject.SetActive(true);
 							subdisp.GetComponent<Subdisplay>().SetDisplay(target.Find("CameraStr/Camera").gameObject.GetComponent<Camera>());
 						}
 

--- a/Assets/Scripts/Debug/RealtimeFidelityProbe.cs
+++ b/Assets/Scripts/Debug/RealtimeFidelityProbe.cs
@@ -8,6 +8,7 @@ namespace PWRISimulator
     /// Time.timeScale による速度倍率設定が実時間で確保できているかを検証する補助コンポーネント。
     /// ratio は直近 ratioWindowSec 秒の移動窓で計算する(#75)。
     /// </summary>
+    [DisallowMultipleComponent]
     public class RealtimeFidelityProbe : MonoBehaviour
     {
         [SerializeField, Min(0.1f)] float logIntervalSec = 1.0f;

--- a/Assets/Scripts/MachineCamControl.cs
+++ b/Assets/Scripts/MachineCamControl.cs
@@ -133,7 +133,7 @@ namespace PWRISimulator
             else
             {
                 UnityEngine.Debug.Log("Object Not NULL");
-                baseLocalX = obj.localPosition.x;
+                baseLocalX = GetNeutralLocalX(machineObj.name) ?? obj.localPosition.x;
             }
 
             var root = GetComponent<UIDocument>().rootVisualElement;
@@ -180,6 +180,36 @@ namespace PWRISimulator
             LeftRightSlider.UnregisterValueChangedCallback(LeftRightSliderOnValueChanged);
             LeftRightSlider.RegisterValueChangedCallback(LeftRightSliderOnValueChanged);
 
+        }
+
+        /// <summary>
+        /// CameraStr の基準 X をプレハブから取得する。
+        /// シーン上の localPosition.x は Update やロード時のカメラ位置復元で
+        /// スライダーのオフセットが加算済みのことがあり、そこから基準を取ると
+        /// 以後の可動域が加算分だけずれる (#127)
+        /// </summary>
+        private static float? GetNeutralLocalX(string machineName)
+        {
+            string prefabPath;
+            if (machineName.Contains("ic120"))
+            {
+                prefabPath = SpawnObject.ic120_path;
+            }
+            else if (Zx200ObjectUtility.IsZx200Name(machineName))
+            {
+                prefabPath = SpawnObject.zx200_path;
+            }
+            else
+            {
+                return null;
+            }
+
+            var prefab = Resources.Load<GameObject>(prefabPath);
+            var cameraStr = prefab != null
+                ? (prefab.transform.Find("base_link/body_link/CameraStr")
+                    ?? prefab.transform.Find("base_link/track_link/CameraStr"))
+                : null;
+            return cameraStr != null ? (float?)cameraStr.localPosition.x : null;
         }
 
         public void ClearCallBack()

--- a/Assets/Scripts/MachineContactMaterialRegistrar.cs
+++ b/Assets/Scripts/MachineContactMaterialRegistrar.cs
@@ -209,6 +209,8 @@ namespace PWRISimulator
       var nativeManager = simulation.Native.getMaterialManager();
 
       // Mirrors ContactMaterialManager.Initialize(entry): create native, bind oriented friction, add explicit.
+      // GetInitialized initializes the clone in place and returns it (or null on failure),
+      // so using clone below is safe once initialized is non-null (#123).
       foreach ( var clone in m_clonedContactMaterials ) {
         var initialized = clone.GetInitialized<ContactMaterial>();
         if ( initialized == null )

--- a/Assets/Scripts/ROS/Publisher/FluidPressureArrayPublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/FluidPressureArrayPublisher.cs
@@ -37,11 +37,26 @@ namespace PWRISimulator.ROS
             while (scheduleOrigin + publishedCount * publishPeriod <= now)
             {
                 DoUpdate();
-                foreach (var item in fluidPressureArrayMsg.array)
-                    MessageUtil.UpdateTimeMsg(item.header.stamp, scheduleOrigin + publishedCount * publishPeriod);
-                PublishMessage();
+                PublishMessage(CreateSnapshot(scheduleOrigin + publishedCount * publishPeriod));
                 publishedCount++;
             }
+        }
+
+        // Publish はメッセージ参照をキューに積むだけで、直列化は送信スレッドが後から行う。
+        // 使い回しの fluidPressureArrayMsg をそのまま渡すと、送信前に次の publish で内容が上書きされ、
+        // 同一ステップ内の連続 publish で stamp が重複・欠落する。複製を渡す (#138)
+        FluidPressureArrayMsg CreateSnapshot(double stampTime)
+        {
+            var array = new FluidPressureMsg[fluidPressureArrayMsg.array.Length];
+            for (int i = 0; i < array.Length; i++)
+            {
+                var src = fluidPressureArrayMsg.array[i];
+                array[i] = new FluidPressureMsg(
+                    MessageUtil.ToHeadermessage(stampTime, src.header.frame_id),
+                    src.fluid_pressure,
+                    src.variance);
+            }
+            return new FluidPressureArrayMsg(array);
         }
         void RegisterTopic()
         {
@@ -76,9 +91,9 @@ namespace PWRISimulator.ROS
 
         /// <returns>fluidPressureArrayMsgの要素数</returns>
         abstract protected uint NumberOfItems();
-        void PublishMessage()
+        void PublishMessage(FluidPressureArrayMsg msg)
         {
-            rosConnection.Publish(topicName, fluidPressureArrayMsg);
+            rosConnection.Publish(topicName, msg);
         }
     }
 }

--- a/Assets/Scripts/ROS/Publisher/FluidPressureArrayPublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/FluidPressureArrayPublisher.cs
@@ -71,8 +71,10 @@ namespace PWRISimulator.ROS
             }
 
             // register publisher
+            // 処理落ち後の追いつき publish のバーストで既定の送信キュー (10) が溢れて
+            // メッセージが捨てられるため、1 秒分を保持できる深さにする (#139)
             rosConnection = ROSConnection.GetOrCreateInstance();
-            rosConnection.RegisterPublisher<FluidPressureArrayMsg>(topicName);
+            rosConnection.RegisterPublisher<FluidPressureArrayMsg>(topicName, (int)Math.Max(10, Frequency()));
         }
 
         /// <summary>

--- a/Assets/Scripts/ROS/Publisher/ImuPublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/ImuPublisher.cs
@@ -67,10 +67,24 @@ namespace PWRISimulator.ROS
             while (scheduleOrigin + publishedCount * publishPeriod <= now)
             {
                 DoUpdate();
-                MessageUtil.UpdateTimeMsg(imuMsg.header.stamp, scheduleOrigin + publishedCount * publishPeriod);
-                PublishMessage();
+                PublishMessage(CreateSnapshot(scheduleOrigin + publishedCount * publishPeriod));
                 publishedCount++;
             }
+        }
+
+        // Publish はメッセージ参照をキューに積むだけで、直列化は送信スレッドが後から行う。
+        // 使い回しの imuMsg をそのまま渡すと、送信前に次の publish で内容が上書きされ、
+        // 同一ステップ内の連続 publish で stamp が重複・欠落する。複製を渡す (#138)。
+        // orientation などは DoUpdate が毎回新しいインスタンスを代入するため参照共有でよい
+        ImuMsg CreateSnapshot(double stampTime)
+        {
+            return new ImuMsg
+            {
+                header = MessageUtil.ToHeadermessage(stampTime, frameId),
+                orientation = imuMsg.orientation,
+                angular_velocity = imuMsg.angular_velocity,
+                linear_acceleration = imuMsg.linear_acceleration,
+            };
         }
 
         void RegisterTopic()
@@ -100,9 +114,9 @@ namespace PWRISimulator.ROS
         {
             return "/upper_body_rot";
         }
-        void PublishMessage()
+        void PublishMessage(ImuMsg msg)
         {
-            rosConnection.Publish(topicName, imuMsg);
+            rosConnection.Publish(topicName, msg);
         }
     }
 }

--- a/Assets/Scripts/ROS/Publisher/ImuPublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/ImuPublisher.cs
@@ -93,7 +93,9 @@ namespace PWRISimulator.ROS
             imuMsg = new();
 
             rosConnection = ROSConnection.GetOrCreateInstance();
-            rosConnection.RegisterPublisher<ImuMsg>(topicName);
+            // 処理落ち後の追いつき publish のバーストで既定の送信キュー (10) が溢れて
+            // メッセージが捨てられるため、1 秒分を保持できる深さにする (#139)
+            rosConnection.RegisterPublisher<ImuMsg>(topicName, Math.Max(10, (int)frequency));
         }
 
         void DoUpdate()

--- a/Assets/Scripts/ROS/Publisher/JointStatePublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/JointStatePublisher.cs
@@ -38,10 +38,22 @@ namespace PWRISimulator.ROS
             while (scheduleOrigin + publishedCount * publishPeriod <= now)
             {
                 DoUpdate();
-                MessageUtil.UpdateTimeMsg(jointStateMsg.header.stamp, scheduleOrigin + publishedCount * publishPeriod);
-                PublishMessage();
+                PublishMessage(CreateSnapshot(scheduleOrigin + publishedCount * publishPeriod));
                 publishedCount++;
             }
+        }
+
+        // Publish はメッセージ参照をキューに積むだけで、直列化は送信スレッドが後から行う。
+        // 使い回しの jointStateMsg をそのまま渡すと、送信前に次の publish で内容が上書きされ、
+        // 同一ステップ内の連続 publish で stamp が重複・欠落する。複製を渡す (#138)
+        JointStateMsg CreateSnapshot(double stampTime)
+        {
+            return new JointStateMsg(
+                header: MessageUtil.ToHeadermessage(stampTime, jointStateMsg.header.frame_id),
+                name: (string[])jointStateMsg.name.Clone(),
+                position: (double[])jointStateMsg.position.Clone(),
+                velocity: (double[])jointStateMsg.velocity.Clone(),
+                effort: (double[])jointStateMsg.effort.Clone());
         }
 
         void RegisterTopic()
@@ -85,9 +97,9 @@ namespace PWRISimulator.ROS
         /// <returns>jointStateMsgの各要素の名前</returns>
         abstract protected string[] JointNames();
 
-        void PublishMessage()
+        void PublishMessage(JointStateMsg msg)
         {
-            rosConnection.Publish(topicName, jointStateMsg);
+            rosConnection.Publish(topicName, msg);
         }
     }
 }

--- a/Assets/Scripts/ROS/Publisher/JointStatePublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/JointStatePublisher.cs
@@ -73,8 +73,10 @@ namespace PWRISimulator.ROS
                 jointStateMsg.name[i] = jointNames[i];
             }
             // register publisher
+            // 処理落ち後の追いつき publish のバーストで既定の送信キュー (10) が溢れて
+            // メッセージが捨てられるため、1 秒分を保持できる深さにする (#139)
             rosConnection = ROSConnection.GetOrCreateInstance();
-            rosConnection.RegisterPublisher<JointStateMsg>(topicName);
+            rosConnection.RegisterPublisher<JointStateMsg>(topicName, (int)Math.Max(10, Frequency()));
         }
 
         /// <summary>

--- a/Assets/Scripts/ROS/Publisher/OdometryPublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/OdometryPublisher.cs
@@ -73,7 +73,9 @@ namespace PWRISimulator.ROS
             odometryMsg.child_frame_id = $"{MachineName()}/base_link";
 
             rosConnection = ROSConnection.GetOrCreateInstance();
-            rosConnection.RegisterPublisher<OdometryMsg>(topicName);
+            // 処理落ち後の追いつき publish のバーストで既定の送信キュー (10) が溢れて
+            // メッセージが捨てられるため、1 秒分を保持できる深さにする (#139)
+            rosConnection.RegisterPublisher<OdometryMsg>(topicName, (int)Math.Max(10, Frequency()));
         }
 
         /// <summary>

--- a/Assets/Scripts/ROS/Publisher/OdometryPublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/OdometryPublisher.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Unity.Robotics.ROSTCPConnector;
+using RosMessageTypes.Geometry;
 using RosMessageTypes.Nav;
 using System;
 
@@ -37,10 +38,31 @@ namespace PWRISimulator.ROS
             while (scheduleOrigin + publishedCount * publishPeriod <= now)
             {
                 DoUpdate();
-                MessageUtil.UpdateTimeMsg(odometryMsg.header.stamp, scheduleOrigin + publishedCount * publishPeriod);
-                PublishMessage();
+                PublishMessage(CreateSnapshot(scheduleOrigin + publishedCount * publishPeriod));
                 publishedCount++;
             }
+        }
+
+        // Publish はメッセージ参照をキューに積むだけで、直列化は送信スレッドが後から行う。
+        // 使い回しの odometryMsg をそのまま渡すと、送信前に次の publish で内容が上書きされ、
+        // 同一ステップ内の連続 publish で stamp が重複・欠落する。
+        // 派生クラスが odometryMsg に odometry を累積するため、作り直しではなく複製を渡す (#138)
+        OdometryMsg CreateSnapshot(double stampTime)
+        {
+            var src = odometryMsg;
+            return new OdometryMsg(
+                header: MessageUtil.ToHeadermessage(stampTime, src.header.frame_id),
+                child_frame_id: src.child_frame_id,
+                pose: new PoseWithCovarianceMsg(
+                    new PoseMsg(
+                        new PointMsg(src.pose.pose.position.x, src.pose.pose.position.y, src.pose.pose.position.z),
+                        new QuaternionMsg(src.pose.pose.orientation.x, src.pose.pose.orientation.y, src.pose.pose.orientation.z, src.pose.pose.orientation.w)),
+                    (double[])src.pose.covariance.Clone()),
+                twist: new TwistWithCovarianceMsg(
+                    new TwistMsg(
+                        new Vector3Msg(src.twist.twist.linear.x, src.twist.twist.linear.y, src.twist.twist.linear.z),
+                        new Vector3Msg(src.twist.twist.angular.x, src.twist.twist.angular.y, src.twist.twist.angular.z)),
+                    (double[])src.twist.covariance.Clone()));
         }
 
         void RegisterTopic()
@@ -67,9 +89,9 @@ namespace PWRISimulator.ROS
 
         /// <returns>更新周期(FPS)</returns>
         abstract protected uint Frequency();
-        void PublishMessage()
+        void PublishMessage(OdometryMsg msg)
         {
-            rosConnection.Publish(topicName, odometryMsg);
+            rosConnection.Publish(topicName, msg);
         }
     }
 }

--- a/Assets/Scripts/ROS/Publisher/PointCloudPublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/PointCloudPublisher.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.ROSTCPConnector;
@@ -31,8 +30,6 @@ namespace PWRISimulator.ROS
 
         PointCloudGenerator generator;
         ROSConnection rosConnection;
-        PointCloud2Msg msg;
-        byte[] dataBuffer = Array.Empty<byte>();
         double scheduleOrigin;
         long publishedCount;
 
@@ -48,15 +45,6 @@ namespace PWRISimulator.ROS
 
             rosConnection = ROSConnection.GetOrCreateInstance();
             rosConnection.RegisterPublisher<PointCloud2Msg>(topicName);
-
-            msg = new PointCloud2Msg
-            {
-                height = 1,
-                is_bigendian = false,
-                is_dense = true,
-                point_step = PointStep,
-                fields = Fields,
-            };
 
             scheduleOrigin = Time.fixedTimeAsDouble;
         }
@@ -81,8 +69,9 @@ namespace PWRISimulator.ROS
             int numPoints = pts.Length / 3;
             int byteSize = numPoints * PointStep;
 
-            if (dataBuffer.Length != byteSize)
-                dataBuffer = new byte[byteSize];
+            // Publish はメッセージ参照をキューに積むだけで、直列化は送信スレッドが後から行うため、
+            // メッセージとデータバッファは使い回さず publish ごとに新規作成する (#138)
+            byte[] dataBuffer = new byte[byteSize];
 
             // Unity (FRU, left-handed) -> ROS (FLU, right-handed):
             // x_ros = z_u, y_ros = -x_u, z_ros = y_u
@@ -97,10 +86,18 @@ namespace PWRISimulator.ROS
                 floatView[3 * i + 2] = uy;
             }
 
-            msg.header = MessageUtil.ToHeadermessage(stampTime, frameId);
-            msg.width = (uint)numPoints;
-            msg.row_step = (uint)byteSize;
-            msg.data = dataBuffer;
+            var msg = new PointCloud2Msg
+            {
+                height = 1,
+                is_bigendian = false,
+                is_dense = true,
+                point_step = PointStep,
+                fields = Fields,
+                header = MessageUtil.ToHeadermessage(stampTime, frameId),
+                width = (uint)numPoints,
+                row_step = (uint)byteSize,
+                data = dataBuffer,
+            };
 
             rosConnection.Publish(topicName, msg);
         }

--- a/Assets/Scripts/ROS/Publisher/SoilVolumePublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/SoilVolumePublisher.cs
@@ -46,7 +46,9 @@ namespace PWRISimulator.ROS
             topicName = $"/{MachineName()}{TopicPhrase()}";
             soilVolumeMsg = new();
             rosConnection = ROSConnection.GetOrCreateInstance();
-            rosConnection.RegisterPublisher<Float64Msg>(topicName);
+            // 処理落ち後の追いつき publish のバーストで既定の送信キュー (10) が溢れて
+            // メッセージが捨てられるため、1 秒分を保持できる深さにする (#139)
+            rosConnection.RegisterPublisher<Float64Msg>(topicName, (int)Math.Max(10, Frequency()));
         }
 
         /// <summary>

--- a/Assets/Scripts/ROS/Publisher/SoilVolumePublisher.cs
+++ b/Assets/Scripts/ROS/Publisher/SoilVolumePublisher.cs
@@ -68,9 +68,11 @@ namespace PWRISimulator.ROS
         /// <returns>更新周期(FPS)</returns>
         abstract protected uint Frequency();
 
+        // Publish はメッセージ参照をキューに積むだけで、直列化は送信スレッドが後から行う。
+        // 使い回しの soilVolumeMsg をそのまま渡すと、送信前に次の publish で値が上書きされ得るため複製を渡す (#138)
         void PublishMessage()
         {
-            rosConnection.Publish(topicName, soilVolumeMsg);
+            rosConnection.Publish(topicName, new Float64Msg(soilVolumeMsg.data));
         }
     }
 }

--- a/Assets/Scripts/ROS/ROSClockPublisher.cs
+++ b/Assets/Scripts/ROS/ROSClockPublisher.cs
@@ -52,10 +52,13 @@ namespace PWRISimulator.ROS
         {
             SetClockMode(m_ClockMode);
             m_ROS = ROSConnection.GetOrCreateInstance();
-            m_ROS.RegisterPublisher<ClockMsg>("clock");
             // publish 周期を fixed step 数に換算する。fixed step (50 Hz) より細かい設定は毎ステップに丸まる
             m_StepInterval = Math.Max(1,
                 (int)Math.Round(1.0 / (Math.Max(m_PublishRateHz, 0.01) * Time.fixedDeltaTime)));
+            // 処理落ち後の追いつき publish のバーストで既定の送信キュー (10) が溢れて
+            // メッセージが捨てられるため、実効レートの 1 秒分を保持できる深さにする (#139)
+            int queueSize = Math.Max(10, (int)Math.Round(1.0 / (m_StepInterval * Time.fixedDeltaTime)));
+            m_ROS.RegisterPublisher<ClockMsg>("clock", queueSize);
         }
 
         void PublishMessage()

--- a/Assets/Scripts/UIcontrol.cs
+++ b/Assets/Scripts/UIcontrol.cs
@@ -691,7 +691,7 @@ namespace PWRISimulator
         }
 
 
-        IEnumerator LoadCoroutine(loadScript loadscript)
+        IEnumerator LoadCoroutine(loadScript loadscript, RuntimeGizmos.TransformGizmo gizmo, string selectedRootName)
         {
             Debug.Log("GlobalVariables.ConfirmWaitFlag: " + GlobalVariables.ConfirmWaitFlag);
             Debug.Log("completedFlag: " + loadscript.completedFlag);
@@ -710,12 +710,22 @@ namespace PWRISimulator
                 //root.Q<UnityEngine.UIElements.Label>("Message").text = "Load completed.";
 
                 loadscript.completedFlag = false;
+
+                // 旧オブジェクトの Destroy はフレーム末に処理されるため、
+                // 1 フレーム待ってから同名の新オブジェクトを選び直す
+                yield return null;
+                ReselectAfterLoad(gizmo, selectedRootName);
             }
         }
 
         void LoadClicked()
         {
             Debug.Log("LoadClicked!");
+
+            // ロードで選択中の対象が作り直されるため、名前を控えてロード後に選び直す (#125)
+            var gizmo = FindObjectOfType<RuntimeGizmos.TransformGizmo>();
+            string selectedRootName = (gizmo != null && gizmo.mainTargetRoot != null)
+                ? gizmo.mainTargetRoot.gameObject.name : null;
 
             loadScript loadscript = null;
 
@@ -734,8 +744,56 @@ namespace PWRISimulator
                 loadscript.OnClick();
             }
 
-            // コルーチンの実行  
-            StartCoroutine(LoadCoroutine(loadscript));
+            // コルーチンの実行
+            StartCoroutine(LoadCoroutine(loadscript, gizmo, selectedRootName));
+        }
+
+        /// <summary>
+        /// ロード後に作り直された同名の対象を選び直し、プレビュー(Subdisplay)と
+        /// 機体カメラのスライダーを更新する (#125)
+        /// </summary>
+        void ReselectAfterLoad(RuntimeGizmos.TransformGizmo gizmo, string selectedRootName)
+        {
+            if (gizmo == null || string.IsNullOrEmpty(selectedRootName)) return;
+
+            // 旧選択は破棄済みオブジェクトを指しているためクリアする
+            gizmo.ClearTargets();
+
+            var newTarget = GameObject.Find(selectedRootName);
+            if (newTarget == null) return;
+
+            var subdisp = GameObject.Find("SubdisplayForSpawnCamera");
+
+            if (GlobalVariables.ActionMode == 1 && selectedRootName.Contains("Camera_"))
+            {
+                gizmo.AddTarget(newTarget.transform);
+
+                var cam = newTarget.transform.Find("CameraStr/Camera");
+                if (subdisp != null && cam != null)
+                {
+                    subdisp.GetComponent<Subdisplay>().SetDisplay(cam.GetComponent<Camera>());
+                }
+            }
+            else if (GlobalVariables.ActionMode == 0 &&
+                     (selectedRootName.Contains("ic120_") || Zx200ObjectUtility.IsZx200Name(selectedRootName)))
+            {
+                gizmo.AddTarget(newTarget.transform);
+
+                Transform cameraStr = newTarget.transform.Find("base_link/body_link/CameraStr")
+                    ?? newTarget.transform.Find("base_link/track_link/CameraStr");
+                Transform cam = cameraStr != null ? cameraStr.Find("Camera") : null;
+                if (subdisp != null && cameraStr != null && cam != null)
+                {
+                    cameraStr.gameObject.SetActive(true);
+                    cam.gameObject.SetActive(true);
+                    subdisp.GetComponent<Subdisplay>().SetDisplay(cam.GetComponent<Camera>());
+                }
+
+                // スライダーのパネルを作り直した機体で初期化し直す
+                var machineCamCont = new MachineObjCamCont();
+                machineCamCont.machineDeselected();
+                machineCamCont.machineSelected(selectedRootName);
+            }
         }
 
 

--- a/Assets/Scripts/UIcontrol.cs
+++ b/Assets/Scripts/UIcontrol.cs
@@ -723,9 +723,32 @@ namespace PWRISimulator
             Debug.Log("LoadClicked!");
 
             // ロードで選択中の対象が作り直されるため、名前を控えてロード後に選び直す (#125)
-            var gizmo = FindObjectOfType<RuntimeGizmos.TransformGizmo>();
+            // gizmo は Main Camera と各機体プレハブに複数あり、カメラ切替で
+            // 非アクティブなことがあるため、includeInactive で探す (#134)
+            RuntimeGizmos.TransformGizmo gizmo = null;
+            foreach (var g in FindObjectsOfType<RuntimeGizmos.TransformGizmo>(true))
+            {
+                if (gizmo == null) gizmo = g;
+                if (g.mainTargetRoot != null)
+                {
+                    gizmo = g;
+                    break;
+                }
+            }
             string selectedRootName = (gizmo != null && gizmo.mainTargetRoot != null)
                 ? gizmo.mainTargetRoot.gameObject.name : null;
+
+            // UI のクリックで gizmo の選択は外れていることがあるため、
+            // スライダーパネルが開いていればその機体を復元対象にする (#134)
+            if (selectedRootName == null)
+            {
+                var panel = FindObjectOfType<MachineCamControl>();
+                if (panel != null)
+                {
+                    selectedRootName = panel.gameObject.name.Replace("_ControlForMachineCamera", "");
+                }
+            }
+            Debug.Log("LoadClicked: selectedRootName=" + (selectedRootName ?? "(none)"));
 
             loadScript loadscript = null;
 
@@ -754,19 +777,31 @@ namespace PWRISimulator
         /// </summary>
         void ReselectAfterLoad(RuntimeGizmos.TransformGizmo gizmo, string selectedRootName)
         {
-            if (gizmo == null || string.IsNullOrEmpty(selectedRootName)) return;
+            if (string.IsNullOrEmpty(selectedRootName))
+            {
+                Debug.Log("ReselectAfterLoad: skipped (no target name)");
+                return;
+            }
 
-            // 旧選択は破棄済みオブジェクトを指しているためクリアする
-            gizmo.ClearTargets();
+            // 旧選択は破棄済みオブジェクトを指しているためクリアする。
+            // gizmo が見つからなくてもパネルとプレビューの復元は行う (#134)
+            if (gizmo != null)
+            {
+                gizmo.ClearTargets();
+            }
 
             var newTarget = GameObject.Find(selectedRootName);
+            Debug.Log("ReselectAfterLoad: name=" + selectedRootName + ", found=" + (newTarget != null) + ", gizmo=" + (gizmo != null) + ", mode=" + GlobalVariables.ActionMode);
             if (newTarget == null) return;
 
             var subdisp = GameObject.Find("SubdisplayForSpawnCamera");
 
             if (GlobalVariables.ActionMode == 1 && selectedRootName.Contains("Camera_"))
             {
-                gizmo.AddTarget(newTarget.transform);
+                if (gizmo != null && gizmo.isActiveAndEnabled)
+                {
+                    gizmo.AddTarget(newTarget.transform);
+                }
 
                 var cam = newTarget.transform.Find("CameraStr/Camera");
                 if (subdisp != null && cam != null)
@@ -777,7 +812,10 @@ namespace PWRISimulator
             else if (GlobalVariables.ActionMode == 0 &&
                      (selectedRootName.Contains("ic120_") || Zx200ObjectUtility.IsZx200Name(selectedRootName)))
             {
-                gizmo.AddTarget(newTarget.transform);
+                if (gizmo != null && gizmo.isActiveAndEnabled)
+                {
+                    gizmo.AddTarget(newTarget.transform);
+                }
 
                 Transform cameraStr = newTarget.transform.Find("base_link/body_link/CameraStr")
                     ?? newTarget.transform.Find("base_link/track_link/CameraStr");

--- a/Assets/Scripts/UIcontrol.cs
+++ b/Assets/Scripts/UIcontrol.cs
@@ -803,9 +803,14 @@ namespace PWRISimulator
                     gizmo.AddTarget(newTarget.transform);
                 }
 
-                var cam = newTarget.transform.Find("CameraStr/Camera");
-                if (subdisp != null && cam != null)
+                // カメラ切替で非アクティブになっていると描画されずプレビューが真っ黒のままになるため、
+                // 機体側と同様に点灯してから表示する (#150)
+                Transform camStr = newTarget.transform.Find("CameraStr");
+                Transform cam = camStr != null ? camStr.Find("Camera") : null;
+                if (subdisp != null && camStr != null && cam != null)
                 {
+                    camStr.gameObject.SetActive(true);
+                    cam.gameObject.SetActive(true);
                     subdisp.GetComponent<Subdisplay>().SetDisplay(cam.GetComponent<Camera>());
                 }
             }

--- a/Assets/Scripts/btn_loadScript.cs
+++ b/Assets/Scripts/btn_loadScript.cs
@@ -279,6 +279,15 @@ namespace PWRISimulator
             Debug.Log("Dump_ObjList.Count: " + GlobalVariables.Dump_ObjList.Count);
 
 
+            // 保存データに名前が含まれるダンプだけを破棄対象にする。
+            // シーン埋め込みの ic120_0 は Dump_ObjList に入らず保存もされないため、
+            // 破棄すると再生成されず消えてしまう (#135)
+            var savedDumpNames = new HashSet<string>();
+            for (int i = 1; i < json_ms.data.Length; i++)
+            {
+                savedDumpNames.Add(json_ms.data[i].name);
+            }
+
             var dumpObjectsToDestroy = new HashSet<GameObject>();
             for (int i = 0; i < GlobalVariables.Dump_ObjList.Count; i++)
             {
@@ -289,7 +298,7 @@ namespace PWRISimulator
             foreach (var dumpInput in FindObjectsOfType<DumpTruckInput>(true))
             {
                 var dumpRoot = dumpInput.transform.root.gameObject;
-                if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name))
+                if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name) && savedDumpNames.Contains(dumpRoot.name))
                     dumpObjectsToDestroy.Add(dumpRoot);
             }
 
@@ -311,7 +320,7 @@ namespace PWRISimulator
             foreach (var dumpInput in FindObjectsOfType<DumpTruckInput>(true))
             {
                 var dumpRoot = dumpInput.transform.root.gameObject;
-                if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name))
+                if (TerrainSaveUtility.IsSavedDumpTruckRootName(dumpRoot.name) && savedDumpNames.Contains(dumpRoot.name))
                 {
                     dumpRoot.SetActive(false);
                 }

--- a/Assets/Scripts/btn_loadScript.cs
+++ b/Assets/Scripts/btn_loadScript.cs
@@ -193,11 +193,19 @@ namespace PWRISimulator
 
 
             // �ύ�
-            StreamReader rd_ds = new StreamReader(Path.Combine(dirPath, "DumpSoil"));
-            string str_ds = rd_ds.ReadToEnd();
-            rd_ds.Close();
+            // DumpSoil は追加ダンプがある場合しか保存されないため、無ければ空データとして扱う (#126)
+            saveScript.SaveDumpSoil json_ds = new saveScript.SaveDumpSoil();
+            json_ds.data = new saveScript.TransDumpSoil[0];
 
-            saveScript.SaveDumpSoil json_ds = JsonUtility.FromJson<saveScript.SaveDumpSoil>(str_ds);
+            string dumpSoilPath = Path.Combine(dirPath, "DumpSoil");
+            if (File.Exists(dumpSoilPath))
+            {
+                StreamReader rd_ds = new StreamReader(dumpSoilPath);
+                string str_ds = rd_ds.ReadToEnd();
+                rd_ds.Close();
+
+                json_ds = JsonUtility.FromJson<saveScript.SaveDumpSoil>(str_ds);
+            }
 
             GlobalVariables.saveDumpSoil = json_ds;
 

--- a/Assets/Scripts/btn_loadScript.cs
+++ b/Assets/Scripts/btn_loadScript.cs
@@ -22,7 +22,7 @@ using Debug = UnityEngine.Debug;
 namespace PWRISimulator
 {
     /// <summary>
-    /// �n�`�̃��[�h����
+    /// 地形のロード処理
     /// </summary>
     public class loadScript : MonoBehaviour
     {
@@ -39,11 +39,11 @@ namespace PWRISimulator
         {
             double time = Time.realtimeSinceStartup;
 
-            // �o�C�i���t�@�C���ǂݍ���
+            // バイナリファイル読み込み
             StreamReader reader = new StreamReader(path + ".ter");
             string jsonString = reader.ReadToEnd();
 
-            // �n�`�f�[�^�̔z��ň���
+            // 地形データの配列で扱う
             saveScript.SaveData save = new saveScript.SaveData();
             save = JsonUtility.FromJson<saveScript.SaveData>(jsonString);
 
@@ -52,15 +52,15 @@ namespace PWRISimulator
 
             foreach (saveScript.SerializedTerrain st in save.list)
             {
-                // �����̃I�u�W�F�N�g������
+                // 同名のオブジェクトを検索
                 GameObject obj = GameObject.Find(st.name);
 
                 if (obj != null)
                 {
-                    // �����̃I�u�W�F�N�g�����݂�����擾
+                    // 同名のオブジェクトが存在したら取得
                     TerrainData terrainData = obj.GetComponent<Terrain>().terrainData;
 
-                    // �n�`�ǂݍ���
+                    // 地形読み込み
                     terrainData.SetAlphamaps(0, 0, ConvertFromFlat(st.alphas, terrainData.alphamapResolution, terrainData.alphamapResolution, terrainData.alphamapLayers));
                     TerrainSaveUtility.ApplySerializedHeights(obj, ConvertFromFlat(st.heights, terrainData.heightmapResolution, terrainData.heightmapResolution));
                 }
@@ -68,7 +68,7 @@ namespace PWRISimulator
 
             Debug.Log("COMPLETED IN " + ((Time.realtimeSinceStartup - time)) + " " + jsonString.Length);
 
-            // ���������t���O
+            // 処理完了フラグ
             completedFlag = true;
         }
 
@@ -142,13 +142,13 @@ namespace PWRISimulator
         }
 
 
-        // �{�^���������ꂽ�ꍇ�ɌĂяo��
+        // ボタンが押された場合に呼び出し
         public void OnClick()
         {
-            // ���������t���O
+            // 処理完了フラグ
             completedFlag = false;
 
-            // �ۑ��f�B���N�g��
+            // 保存ディレクトリ
             var dirPath = "";
             if (GlobalVariables.ActionMode == 3)
             {
@@ -159,7 +159,7 @@ namespace PWRISimulator
                 dirPath = Path.Combine(GlobalVariables.BACKUP_FOLDER, setDirName);
             }
 
-            // �ۑ��f�B���N�g�����Ȃ���Γǂݍ��߂Ȃ��̂ŏI��
+            // 保存ディレクトリがなければ読み込めないので終了
             if (!Directory.Exists(dirPath))
             {
                 completedFlag = true;
@@ -168,9 +168,9 @@ namespace PWRISimulator
 
 
             //----------
-            // �ۑ��n�̃t�@�C���ǂݍ���
+            // 保存系のファイル読み込み
             //----------
-            // �p��
+            // 姿勢
             StreamReader rd_ms = new StreamReader(Path.Combine(dirPath, "MachinesJoints"));
             string str_ms = rd_ms.ReadToEnd();
             rd_ms.Close();
@@ -192,7 +192,7 @@ namespace PWRISimulator
             }
 
 
-            // �ύ�
+            // 積載
             StreamReader rd_ds = new StreamReader(Path.Combine(dirPath, "DumpSoil"));
             string str_ds = rd_ds.ReadToEnd();
             rd_ds.Close();
@@ -202,7 +202,7 @@ namespace PWRISimulator
             GlobalVariables.saveDumpSoil = json_ds;
 
 
-            // �y�뗱�q���f��
+            // 土壌粒子モデル
             StreamReader rd = new StreamReader(Path.Combine(dirPath, "SoilParticles"));
             string str_p = rd.ReadToEnd();
             rd.Close();
@@ -213,18 +213,18 @@ namespace PWRISimulator
 
 
             //----------
-            // �n�`�ēǂݍ���
+            // 地形再読み込み
             //----------
-            // �D�^�G���A�̃J�E���g���Z�b�g
+            // 泥濘エリアのカウントリセット
             GlobalVariables.countMat.Clear();
 
-            // AGX�n�`�擾
+            // AGX地形取得
             if (terrain == null)
             {
                 terrain = FindObjectOfType<DeformableTerrain>();
             }
 
-            // �y�뗱�q���f�����폜
+            // 土壌粒子モデルを削除
             var soilSim = terrain.Native?.getSoilSimulationInterface();
             var soilParticles = soilSim.getSoilParticles();
 
@@ -233,32 +233,32 @@ namespace PWRISimulator
                 soilSim.removeSoilParticle(soilParticles.at(i));
             }
 
-            // �n�`��Ǎ�
+            // 地形を読込
             DeserializeTerrain(Path.Combine(dirPath, fileName));
 
-            // �n�`�X�R�A�����O�̃��Z�b�g
+            // 地形スコアリングのリセット
             TerrainScore.Reset();
 
 
             //----------
-            // �d�@�ēǂݍ���
+            // 重機再読み込み
             //----------
-            // �V���x���J�[�폜
+            // ショベルカー削除
             GameObject _shovelObj = Zx200ObjectUtility.FindZx200Object();
             if (_shovelObj != null)
             {
                 UnityEngine.Object.Destroy(_shovelObj);
             }
 
-            // �ʒu
+            // 位置
             Vector3 _pos = new Vector3((float)json_ms.data[0].p.x, (float)json_ms.data[0].p.y, (float)json_ms.data[0].p.z);
             Debug.Log(_pos);
 
-            // ��]
+            // 回転
             Quaternion _qut = new Quaternion((float)json_ms.data[0].q.x, (float)json_ms.data[0].q.y, (float)json_ms.data[0].q.z, (float)json_ms.data[0].q.w);
             Debug.Log(_qut);
 
-            // �V���x���J�[�Ĕz�u
+            // ショベルカー再配置
             GameObject zx200_prefab = Resources.Load<GameObject>(SpawnObject.zx200_path);
             GameObject shovelObj = (GameObject)UnityEngine.Object.Instantiate(zx200_prefab, _pos, _qut);
             shovelObj.name = string.IsNullOrEmpty(json_ms.data[0].name) ? SpawnObject.zx200_objName : json_ms.data[0].name;
@@ -285,12 +285,12 @@ namespace PWRISimulator
                     dumpObjectsToDestroy.Add(dumpRoot);
             }
 
-            // �_���v�g���b�N�폜
+            // ダンプトラック削除
             foreach (GameObject dumpObj in dumpObjectsToDestroy)
             {
                 if (dumpObj != null)
                 {
-                    // �폜
+                    // 削除
                     dumpObj.SetActive(false);
                     Destroy(dumpObj);
                     GameObject objMassBody = GameObject.Find(dumpObj.name + "_SoilMassBody");
@@ -309,24 +309,24 @@ namespace PWRISimulator
                 }
             }
 
-            // �ێ����Ă���_���v�g���b�N�I�u�W�F�N�g���X�g�̃N���A
+            // 保持しているダンプトラックオブジェクトリストのクリア
             GlobalVariables.Dump_IDList.Clear();
             GlobalVariables.Dump_ObjList.Clear();
 
             GlobalVariables.ic120Counter = 0;
 
 
-            // �_���v�g���b�N�Ɋւ�����ǂݍ���
+            // ダンプトラックに関する情報読み込み
             for (int i = 1; i < json_ms.data.Length; i++)
             {
-                // �Ĕz�u
+                // 再配置
                 GameObject ic120_prefab = Resources.Load<GameObject>("Prefabs/ic120_prefVar");
                 GameObject ic120obj = (GameObject)UnityEngine.Object.Instantiate(ic120_prefab, json_ms.data[i].p, json_ms.data[i].q);
                 ic120obj.name = json_ms.data[i].name;
 
-                // ID��ێ�
+                // IDを保持
                 GlobalVariables.Dump_IDList.Add(json_ms.data[i].id);
-                // �I�u�W�F�N�g��ێ�
+                // オブジェクトを保持
                 GlobalVariables.Dump_ObjList.Add(ic120obj);
 
                 GlobalVariables.ic120Counter += 1;
@@ -334,9 +334,9 @@ namespace PWRISimulator
 
 
             //----------
-            // �J�����ēǂݍ���
+            // カメラ再読み込み
             //----------
-            // ���ݔz�u����Ă���J�������폜
+            // 現在配置されているカメラを削除
             List<Camera> cameras = new List<Camera>();
             cameras.AddRange(FindObjectsOfType<Camera>(true));
 
@@ -344,23 +344,23 @@ namespace PWRISimulator
             {
                 //Debug.Log(cameras[i].gameObject.transform.root.gameObject.name.Contains("Camera_"));
 
-                // �ǉ������J�����̂ݍ폜
+                // 追加したカメラのみ削除
                 if (cameras[i].gameObject.transform.root.gameObject.name.Contains("Camera_"))
                 {
                     UnityEngine.Object.Destroy(cameras[i].gameObject.transform.root.gameObject);
                 }
             }
 
-            // �J�����̃J�E���g���Z�b�g
+            // カメラのカウントリセット
             GlobalVariables.CameraCounter = 0;
 
 
-            // �J�����ʒu�ǂݍ���
+            // カメラ位置読み込み
             for (int i = 0; i < json_ms.camera.Length; i++)
             {
                 if (json_ms.camera[i].name.Contains("Camera_"))
                 {
-                    // �ǉ������J����
+                    // 追加したカメラ
                     var cameraObj = new cameraObj();
                     cameraObj.Spawn_Camera(json_ms.camera[i].p, json_ms.camera[i].q, Int32.Parse(json_ms.camera[i].id), SpawnObject.camera_path);
 
@@ -375,7 +375,7 @@ namespace PWRISimulator
                 }
                 else if (json_ms.camera[i].name.Contains("MainCameraStr"))
                 {
-                    // ���C���J����
+                    // メインカメラ
                     var obj = GameObject.Find(json_ms.camera[i].name);
                     if (obj != null)
                     {
@@ -386,18 +386,18 @@ namespace PWRISimulator
                 }
                 else
                 {
-                    // �d�@�̃J����
+                    // 重機のカメラ
                     GameObject obj = null;
                     if (json_ms.camera[i].name.Contains("zx200"))
                     {
-                        // �V���x���J�[
+                        // ショベルカー
                         var shovelCameraStr = shovelObj.transform.Find("base_link/body_link/CameraStr")
                             ?? shovelObj.transform.Find("base_link/track_link/CameraStr");
                         obj = shovelCameraStr != null ? shovelCameraStr.gameObject : null;
                     }
                     else
                     {
-                        // �_���v�g���b�N
+                        // ダンプトラック
                         for (int j = 0; j < GlobalVariables.Dump_ObjList.Count; j++)
                         {
                             if (GlobalVariables.Dump_ObjList[j].name == json_ms.camera[i].name)
@@ -423,7 +423,7 @@ namespace PWRISimulator
 
 
 
-            // �D�^�G���A�̃J�E���g�s��Ǎ�
+            // 泥濘エリアのカウント行列読込
             using (StreamReader sr = new StreamReader(Path.Combine(dirPath, "MudAreaMatrix")))
             {
                 string content = sr.ReadToEnd();
@@ -466,10 +466,10 @@ namespace PWRISimulator
             //}
 
 
-            // �J�E���g���Z�b�g
+            // カウントリセット
             GlobalVariables.SetupJointDumpCount = 0;
 
-            // �t���O��؂�ւ��ē���J�n
+            // フラグを切り替えて動作開始
             GlobalVariables.SetupJointFlag = true;
             GlobalVariables.SetupJointDumpFlag = true;
 

--- a/Assets/Scripts/btn_saveScript.cs
+++ b/Assets/Scripts/btn_saveScript.cs
@@ -20,7 +20,7 @@ using Debug = UnityEngine.Debug;
 namespace PWRISimulator
 {
     /// <summary>
-    /// �n�`�̃Z�[�u����
+    /// 地形のセーブ処理
     /// </summary>
     public class saveScript : MonoBehaviour
     {
@@ -71,7 +71,7 @@ namespace PWRISimulator
             public double z;
         }
 
-        // �_���v�g���b�N�̐ύ�
+        // ダンプトラックの積載
         [System.Serializable]
         public class SaveDumpSoil
         {
@@ -85,7 +85,7 @@ namespace PWRISimulator
             public double mass;
         }
 
-        // �d�@�̎p��(���ԂƃX�R�A���ǉ�)
+        // 重機の姿勢(時間とスコアも追加)
         [System.Serializable]
         public class SaveMachines
         {
@@ -140,7 +140,7 @@ namespace PWRISimulator
 
             int i = 0;
 
-            // �e���C���f�[�^���擾
+            // テレインデータを取得
             foreach (Terrain _terrain in Terrain.activeTerrains)
             {
                 TerrainData terrainData = _terrain.terrainData;
@@ -164,7 +164,7 @@ namespace PWRISimulator
             Debug.Log("SaveScript COMPLETED IN " + ((Time.realtimeSinceStartup - time)) + " " + json.Length);
 
 
-            // ���������t���O
+            // 処理完了フラグ
             completedFlag = true;
         }
 
@@ -238,13 +238,13 @@ namespace PWRISimulator
         }
 
 
-        // �{�^���������ꂽ�ꍇ�ɌĂяo��
+        // ボタンが押された場合に呼び出し
         public void OnClick()
         {
-            // ���������t���O
+            // 処理完了フラグ
             completedFlag = false;
 
-            // �ۑ��f�B���N�g��
+            // 保存ディレクトリ
             var dirPath = "";
             if (GlobalVariables.ActionMode == 3)
             {
@@ -255,7 +255,7 @@ namespace PWRISimulator
                 dirPath = Path.Combine(GlobalVariables.BACKUP_FOLDER, setDirName);
             }
 
-            // �ۑ��f�B���N�g�����Ȃ���΍쐬
+            // 保存ディレクトリがなければ作成
             if (!Directory.Exists(dirPath))
             {
                 Directory.CreateDirectory(dirPath);
@@ -263,12 +263,12 @@ namespace PWRISimulator
 
 
 
-            // ���ԂƃX�R�A��ێ�
+            // 時間とスコアを保持
             var myTime = CountdownTimer.timeRemaining;
             var myScore = GlobalVariables.score;
 
 
-            // �n�`���q���f�����擾
+            // 地形粒子モデルを取得
             if (terrain == null)
             {
                 terrain = FindObjectOfType<DeformableTerrain>();
@@ -287,7 +287,7 @@ namespace PWRISimulator
                     //Debug.Log("Index: " + i);
                     save.data[i] = new Particles();
 
-                    // agx::Physics::GranularBodyPtr ����ʒu��a���擾
+                    // agx::Physics::GranularBodyPtr から位置や径を取得
                     var pos = soilParticles.at(i).getPosition();
                     //Debug.Log("Position: " + pos[0] + ", " + pos[1] + ", " + pos[2]);
                     save.data[i].position = new agxVec3();
@@ -312,7 +312,7 @@ namespace PWRISimulator
                 }
             }
 
-            // �n�`���q���f����ۑ�
+            // 地形粒子モデルを保存
             if (save.data != null)
             {
                 string json = JsonUtility.ToJson(save, true);
@@ -323,23 +323,23 @@ namespace PWRISimulator
             }
 
 
-            // �n�`��ۑ�
+            // 地形を保存
             SerializeTerrain(Path.Combine(dirPath, fileName));
 
 
-            // �d�@�̎p���ێ�
+            // 重機の姿勢保持
             SaveMachines sm = new SaveMachines();
             int num = (int)GlobalVariables.Dump_ObjList.Count + 1;
             sm.data = new objProperties[num];
             sm.data[0] = new objProperties();
 
 
-            // ���ԂƃX�R�A
+            // 時間とスコア
             sm.time = myTime;
             sm.score = myScore;
 
 
-            // �J�����z�u�ۑ�
+            // カメラ配置保存
             List<Camera> cameras = new List<Camera>();
             cameras.AddRange(FindObjectsOfType<Camera>(true));
 
@@ -398,7 +398,7 @@ namespace PWRISimulator
             }
 
 
-            // �V���x���J�[�̎p���Ɣz�u���擾
+            // ショベルカーの姿勢と配置を取得
             GameObject shovelObj = Zx200ObjectUtility.FindZx200Object();
 
             var shovelInput = shovelObj.GetComponent<ExcavatorInput>();
@@ -424,7 +424,7 @@ namespace PWRISimulator
             Debug.Log("Dump_ObjList.Count: " + GlobalVariables.Dump_ObjList.Count);
 
 
-            // �_���v�g���b�N�̎p���Ɣz�u���擾
+            // ダンプトラックの姿勢と配置を取得
             if ((int)GlobalVariables.Dump_ObjList.Count > 0)
             {
                 SaveDumpSoil sd = new SaveDumpSoil();
@@ -461,7 +461,7 @@ namespace PWRISimulator
                     sm.data[i + 1].joint.dump_joint = dumpJoint.dump_joint.CurrentPosition;
                 }
 
-                // �_���v�g���b�N�̐ύڕۑ�
+                // ダンプトラックの積載保存
                 if (sd.data != null)
                 {
                     string json_sd = JsonUtility.ToJson(sd, true);
@@ -473,7 +473,7 @@ namespace PWRISimulator
             }
 
 
-            // �d�@�̎p����ۑ�
+            // 重機の姿勢を保存
             if (sm.data != null)
             {
                 string json_sm = JsonUtility.ToJson(sm, true);
@@ -483,7 +483,7 @@ namespace PWRISimulator
                 }
             }
 
-            // �D�^�G���A�̃J�E���g�s���ۑ�
+            // 泥濘エリアのカウント行列を保存
             using (StreamWriter sw = new StreamWriter(Path.Combine(dirPath, "MudAreaMatrix")))
             {
                 //sw.Write(GlobalVariables.countMat);

--- a/Assets/Tests/PlayMode/SimulationSaveLoadTests.cs
+++ b/Assets/Tests/PlayMode/SimulationSaveLoadTests.cs
@@ -291,6 +291,12 @@ namespace PWRISimulator.Tests
             int dumpTruckCount = 0;
             foreach (var go in machineRoots)
             {
+                // DumpSoil creates an auxiliary "<machine>_SoilMassBody" rigid body at the
+                // scene root (it cannot live under an ArticulatedRoot), which would match
+                // the ic120 prefix below even though it is not a machine (#151).
+                if (go.name.Contains("_SoilMassBody"))
+                    continue;
+
                 if (go.name.StartsWith("zx200", StringComparison.OrdinalIgnoreCase))
                     excavatorCount++;
                 else if (go.name.StartsWith("ic120", StringComparison.OrdinalIgnoreCase))

--- a/WebApp/client/public/receiver/index.html
+++ b/WebApp/client/public/receiver/index.html
@@ -26,6 +26,13 @@
       <label><input type="checkbox" class="cameraCheckbox" value="3" data-label="Camera3" autocomplete="off" />Camera3</label>
     </fieldset>
 
+    <div class="box">
+      <span>Codec preferences:</span>
+      <select id="codecPreferences" autocomplete="off" disabled>
+        <option selected value="">Default</option>
+      </select>
+    </div>
+
     <p>
       Check one or more cameras to stream them into the grid above. Cameras can be added or removed at any time after the initial play.
     </p>

--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -1,4 +1,5 @@
 import { getServerConfig, getRTCConfiguration } from "../../js/config.js";
+import { createDisplayStringArray } from "../../js/stats.js";
 import { RenderStreaming } from "../../module/renderstreaming.js";
 import { Signaling, WebSocketSignaling } from "../../module/signaling.js";
 
@@ -12,6 +13,10 @@ let streamingActive = false;
 const playerGrid = document.getElementById('playerGrid');
 const messageDiv = document.getElementById('message');
 messageDiv.style.display = 'none';
+
+const codecPreferences = document.getElementById('codecPreferences');
+const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
+  'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
 
 /** @type {HTMLInputElement[]} */
 const cameraCheckboxes = Array.from(document.querySelectorAll('input.cameraCheckbox'));
@@ -53,6 +58,7 @@ async function setup() {
     cb.addEventListener('change', onCheckboxChange);
   }
 
+  showCodecSelect();
   showPlayButton();
 }
 
@@ -79,12 +85,16 @@ async function onClickPlayButton() {
   playButton.style.display = 'none';
   streamingActive = true;
 
+  // ストリーミング開始後にコーデック選択を固定
+  codecPreferences.disabled = true;
+
   for (const cb of cameraCheckboxes) {
     if (cb.checked) {
       await startStream(cb.value, cb.dataset.label || cb.value);
     }
   }
   updateGridLayout();
+  startStatsPolling();
 }
 
 async function onCheckboxChange(evt) {
@@ -144,7 +154,16 @@ async function startStream(cameraValue, label) {
     }
   };
   renderstreaming.onDisconnect = () => {
-    stopStream(cameraValue).then(updateGridLayout);
+    stopStream(cameraValue).then(() => {
+      updateGridLayout();
+      if (streams.size === 0) {
+        stopStatsPolling();
+      }
+    });
+  };
+  // onGotOffer でコーデック選択を全ストリームに適用
+  renderstreaming.onGotOffer = () => {
+    applyCodecPreferences(renderstreaming);
   };
 
   /** @type {StreamEntry} */
@@ -181,11 +200,15 @@ function updateGridLayout() {
   if (n === 0) {
     playerGrid.style.gridTemplateColumns = '1fr';
     playerGrid.style.gridTemplateRows = '1fr';
-    if (streamingActive && !document.getElementById('playButton')) {
-      // No streams but session was started: let user re-add by clicking the button again
+    if (streamingActive) {
+      // No streams but session was started: let user re-add by clicking the button again.
+      // playButton is hidden (not removed) after play, so re-show it instead of
+      // testing for its absence (#120).
       showPlayButton();
       playButton.style.display = '';
       streamingActive = false;
+      codecPreferences.disabled = false;
+      stopStatsPolling();
     }
     return;
   }
@@ -193,4 +216,98 @@ function updateGridLayout() {
   const rows = Math.ceil(n / cols);
   playerGrid.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
   playerGrid.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+}
+
+// ─── Codec selection ───────────────────────────────────────────────
+
+function showCodecSelect() {
+  if (!supportsSetCodecPreferences) {
+    messageDiv.style.display = 'block';
+    messageDiv.innerHTML = `Current Browser does not support <a href="https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/setCodecPreferences">RTCRtpTransceiver.setCodecPreferences</a>.`;
+    return;
+  }
+
+  const codecs = RTCRtpSender.getCapabilities('video').codecs;
+  codecs.forEach(codec => {
+    if (['video/red', 'video/ulpfec', 'video/rtx'].includes(codec.mimeType)) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = (codec.mimeType + ' ' + (codec.sdpFmtpLine || '')).trim();
+    option.innerText = option.value;
+    codecPreferences.appendChild(option);
+  });
+  codecPreferences.disabled = false;
+}
+
+/**
+ * 選択中のコーデックを指定 RenderStreaming インスタンスの全 video transceiver に適用する。
+ * onGotOffer 発火時に各ストリームから呼ばれる。
+ */
+function applyCodecPreferences(rs) {
+  if (!supportsSetCodecPreferences) return;
+
+  const preferredCodec = codecPreferences.options[codecPreferences.selectedIndex];
+  if (!preferredCodec || preferredCodec.value === '') return;
+
+  const [mimeType, sdpFmtpLine] = preferredCodec.value.split(' ');
+  const { codecs } = RTCRtpSender.getCapabilities('video');
+  const selectedCodec = codecs.find(c => c.mimeType === mimeType && c.sdpFmtpLine === sdpFmtpLine);
+  if (!selectedCodec) return;
+
+  const transceivers = rs.getTransceivers();
+  if (transceivers && transceivers.length > 0) {
+    transceivers
+      .filter(t => t.receiver.track.kind === 'video')
+      .forEach(t => t.setCodecPreferences([selectedCodec]));
+  }
+}
+
+// ─── Statistics overlay ────────────────────────────────────────────
+
+/** @type {Map<string, RTCStatsReport>} 各ストリームの直近 stats (bitrate 計算用) */
+const lastStatsByCamera = new Map();
+/** @type {number} */
+let statsIntervalId = null;
+
+function startStatsPolling() {
+  if (statsIntervalId) return;
+  statsIntervalId = setInterval(pollStats, 1000);
+}
+
+function stopStatsPolling() {
+  if (statsIntervalId) {
+    clearInterval(statsIntervalId);
+    statsIntervalId = null;
+  }
+  lastStatsByCamera.clear();
+  messageDiv.style.display = 'none';
+  messageDiv.innerHTML = '';
+}
+
+async function pollStats() {
+  if (streams.size === 0) return;
+
+  const lines = [];
+  for (const [cameraValue, entry] of streams) {
+    try {
+      const stats = await entry.renderstreaming.getStats();
+      if (!stats) continue;
+
+      const last = lastStatsByCamera.get(cameraValue);
+      const array = createDisplayStringArray(stats, last);
+      if (array.length) {
+        lines.push(`[${entry.label}]`);
+        lines.push(...array);
+      }
+      lastStatsByCamera.set(cameraValue, stats);
+    } catch (e) {
+      // ストリーム停止中などは無視
+    }
+  }
+
+  if (lines.length) {
+    messageDiv.style.display = 'block';
+    messageDiv.innerHTML = lines.join('<br>');
+  }
 }


### PR DESCRIPTION
PR #94 の受入(7362de98)後にこちらで実施した修正の反映です。
head は PR #94 と同じ `hackathon-komori` で、受入後の upstream hackathon(00863f38)を取り込んだ上に修正を積んでいるため、競合はありません。

## 含まれる修正

**PR #94 レビューコメントへの対応**

- `e55142a3` receiver にコーデック選択と統計表示を復活(項目 3。入力フォワーディングは方針どおり復元していません)
- `1e2b57e0` `GetInitialized` が clone 自身を初期化して返す意図をコメントで明記(項目 7)
- `1523c8c1` `RealtimeFidelityProbe` に `DisallowMultipleComponent` を付与(項目 8)
- 項目 4(/clock)は下記の実測報告のとおり、コード変更なしとしました

**Save / Load まわりの不具合修正**

- `72b6accf` 追加ダンプなしで保存したデータの Load が DumpSoil の FileNotFoundException で中断していたのを修正
- `72b8630e` Load でシーン埋め込みの ic120_0 が破棄されたまま再生成されず消えていたのを修正
- `4c3a5dd7` `2aec8430` Load 後にプレビューとカメラスライダーを選び直すようにし、UI クリックで gizmo の選択が外れていてもスライダーパネルから復元対象を割り出すように修正
- `568a0113` カメラスライダーの基準位置をプレハブから取得し、Load 後に可動域がずれる問題を修正
- `bb4396d2` Camera Settings で配置済みカメラを選択したときにプレビューが真っ黒のままだったのを修正(選択時にカメラを点灯)

**ROS 配信まわり**

- `241c0839` publisher のメッセージ使い回しで、同一ステップ内の連続 publish の 1 件目が送信前に上書きされ stamp が重複・欠落していたのを修正(publish ごとに複製)
- `1b7d715a` 処理落ちからの追いつき publish で送信キュー(既定 10)が溢れてメッセージが丸ごと欠落していたのを修正(1 秒分に拡大)

**その他**

- `038027a3` ほか:受入マージで btn_loadScript.cs / btn_saveScript.cs の日本語コメントが置換文字の焼き付いた文字化け版に退行していたため、受入前の正常なコメントを復元(コード変更なし)
- `5b696407` PlayMode テスト `Scene_HasExpectedMachineRootCounts` が補助ボディ `ic120_0_SoilMassBody` をダンプと誤カウントして失敗していたのを修正

## PR #94 レビュー項目 4(/clock の配信タイミング)の実測報告

レビューで依頼のあった「ROS 側でどう見えるか」の確認を実施しました。

計測環境:Unity Editor Play(fixed step 0.02 s)、WSL2 Ubuntu + ROS2 Humble + ros_tcp_endpoint。
`ros2 topic hz` / `ros2 topic echo` で stamp を採取し、間隔・単調性・欠落を集計しました。
結果 1 と結果 2 は Sim Speed 1.0 で計測しています。1.5〜4.0 は Windows ビルドで追試し、結果 3 にまとめました。

**結果 1:/clock は均一グリッドで、ティック落ちやドリフトは起きていない**

- stamp は 20 ms 間隔の均一なグリッドで単調増加し、欠落はゼロでした
- 現方式は「fixed step 何回ごとに publish するか」を整数で決める方式(以下、整数ステップ間隔方式)のため、stamp は常に fixed step の整数倍の均一グリッドになります
- 設定 100 Hz に対して実効 50 Hz になるのは fixed step 上限への量子化で、コード内コメントに明記した既知の挙動です
- ウォールクロックタイムでのレートは約 30.5 Hz でしたが、これは Editor 実行で物理が実時間の約 61% でしか進めないためです。/zx200/joint_states との比が 30.5 : 37.7 ≈ 50 : 60 となり、sim 時間上は両者とも設計どおりでした
- ご指摘のとおり ROS-TCP-Connector は送信をメインスレッドでまとめて行うため、到着タイミングはどちらの方式でもバースト的で、while 方式へ変えても `ros2 topic hz` の見え方は変わりません

**結果 2:一方 while 方式側に stamp の破損を発見(本 PR で修正済み)**

- /zx200/joint_states(60 Hz)で、0.1 秒に 1 回(60 Hz と 50 Hz のうなり周期)、重複 stamp とグリッド欠落の対を観測しました(10.7 sim 秒で各 107 件)
- 原因は while 方式のメッセージ使い回しです。ROS-TCP-Connector の Publish メソッドの実装は、メッセージ参照をキューに積むだけで直列化は送信スレッドが後から行うため、同一 FixedUpdate 内に 2 回 publish すると、1 件目が送信される前に stamp が 2 件目の値で上書きされてしまうことが分かりました
- 本 PR の `241c0839` で修正し、再実測で joint_states と main_fluid_pressure の重複・欠落が 0 件になることを確認しました

**結果 3:Sim Speed 1.5〜4.0 でも sim 時間上のグリッドは不変**

速度倍率は `Time.timeScale` のみに適用され fixed step は変わらないため、理屈の上では倍率を変えてもウォールクロックでのレートが変わるだけのはずです。これを確かめるため、rclpy で /clock と /zx200/joint_states の stamp を各倍率 30 秒ずつ採取しました(1.0 は同じ計測系での比較用)。

| 設定 | 実効倍率 | /clock ウォールクロックレート | /clock sim レート | 重複 / 欠落 |
|---|---|---|---|---|
| 1.0 | 1.00x | 50.2 Hz | 50.00 Hz | 0 / 0 |
| 1.5 | 1.51x | 75.3 Hz | 50.00 Hz | 0 / 0 |
| 2.0 | 1.93x | 96.5 Hz | 50.00 Hz | 0 / 0 |
| 3.0 | 1.87x | 93.5 Hz | 50.00 Hz | 0 / 0 |
| 4.0 | 1.92x | 95.8 Hz | 50.00 Hz | 0 / 0 |

- どの倍率でも /clock の stamp は 20 ms(sim 時間)の均一グリッドで単調増加し、重複・欠落はゼロでした。joint_states も sim 時間上 60.00 Hz のままで、/clock との 50 : 60 の関係は変わりません
- 計測マシンは毎秒約 95 fixed step で飽和し、設定 3.0 と 4.0 の実効倍率は約 1.9x で頭打ちでした。倍率が実時間で確保できているかの検知は `RealtimeFidelityProbe` の役割で、飽和しても stamp の品質は劣化しません
- 最高レート(joint_states 約 116 msg/s)でも欠落はなく、送信キューの拡大(`1b7d715a`)で足りています
- 計測上の注記:計測に使った WSL2 の monotonic 時計が実時間より 5〜8% 遅く進んでいたため、ウォールクロック値は Windows 側の時計を基準に換算しています

**結論**

- /clock の方式は現状のまま変更しない判断をしました
- 上記の stamp 破損自体は `241c0839` で解消しており、while 方式へ統一しても破損は起きませんが、 while 方式で clock を 50 Hz 超に設定すると、fixed step(20 ms)の間の実際には計算されていない時刻を配信することになります。整数ステップ間隔方式は設定レートを実効レートへ量子化し、実在する sim 時刻のみを配信するため、現状の設定を維持します

## 検証

- PlayMode テスト(2022.3.62f3、グラフィックスありの CLI 実行):14 passed / 0 failed / 3 skipped(元から Ignore 指定のもの)
- コマンドラインビルド(-buildWindows64Player)で、ビルド対象が GameScene のみであることと、起動後に GameScene のブートストラップが例外なく完走することを確認済み
- Save / Load、スライダー復元、カメラプレビューは Unity Editor の Play モードで手動確認済み



